### PR TITLE
Add z channel types

### DIFF
--- a/packages/graphic-walker/src/config.ts
+++ b/packages/graphic-walker/src/config.ts
@@ -14,6 +14,7 @@ const CHART_LAYOUT_TYPE: ('auto' | 'fixed' | 'full')[] = ['auto', 'fixed', 'full
 const CHANNEL_LIMIT = {
     rows: Infinity,
     columns: Infinity,
+    z: Infinity,
     color: 1,
     opacity: 1,
     size: 1,

--- a/packages/graphic-walker/src/fields/fieldsContext.tsx
+++ b/packages/graphic-walker/src/fields/fieldsContext.tsx
@@ -116,6 +116,7 @@ export default FieldsContextWrapper;
 export const DRAGGABLE_STATE_KEYS: Readonly<IDraggableStateKey[]> = [
     { id: 'columns', mode: 0 },
     { id: 'rows', mode: 0 },
+    { id: 'z', mode: 0 },
     { id: 'color', mode: 1 },
     { id: 'opacity', mode: 1 },
     { id: 'size', mode: 1 },

--- a/packages/graphic-walker/src/interfaces.ts
+++ b/packages/graphic-walker/src/interfaces.ts
@@ -285,6 +285,7 @@ export interface DraggableFieldState {
     measures: IViewField[];
     rows: IViewField[];
     columns: IViewField[];
+    z: IViewField[];
     color: IViewField[];
     opacity: IViewField[];
     size: IViewField[];
@@ -379,6 +380,7 @@ export interface IVisualConfig {
     resolve: {
         x?: boolean;
         y?: boolean;
+        z?: boolean;
         color?: boolean;
         opacity?: boolean;
         shape?: boolean;
@@ -399,6 +401,7 @@ export interface IVisualConfig {
 export interface IConfigScaleSet {
     row?: IConfigScale;
     column?: IConfigScale;
+    z?: IConfigScale;
     color?: IConfigScale;
     opacity?: IConfigScale;
     size?: IConfigScale;
@@ -419,6 +422,7 @@ export interface IVisualLayout {
     resolve: {
         x?: boolean;
         y?: boolean;
+        z?: boolean;
         color?: boolean;
         opacity?: boolean;
         shape?: boolean;
@@ -862,6 +866,7 @@ export type IFieldInfos = {
 export interface IChannelScales {
     row?: IScale | ((info: IFieldInfos) => IScale);
     column?: IScale | ((info: IFieldInfos) => IScale);
+    z?: IScale | ((info: IFieldInfos) => IScale);
     color?: IColorScale | ((info: IFieldInfos) => IColorScale);
     opacity?: IScale | ((info: IFieldInfos) => IScale);
     size?: IScale | ((info: IFieldInfos) => IScale);


### PR DESCRIPTION
## Summary
- extend `DraggableFieldState` with `z`
- allow optional `z` scales and resolve flags
- register `z` in draggable keys
- add default channel limit for `z`

## Testing
- `yarn test` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_685a70e935b0832a81c3bf09f378eb3b