### PR TITLE
Add z channel support for Vega specs

### DIFF
--- a/packages/graphic-walker/src/lib/vega.ts
+++ b/packages/graphic-walker/src/lib/vega.ts
@@ -12,6 +12,7 @@ export function toVegaSpec({
     color,
     opacity,
     size,
+    z,
     details = [],
     radius,
     shape,
@@ -35,6 +36,7 @@ export function toVegaSpec({
     color?: IViewField;
     opacity?: IViewField;
     size?: IViewField;
+    z?: IViewField;
     shape?: IViewField;
     theta?: IViewField;
     radius?: IViewField;
@@ -70,7 +72,7 @@ export function toVegaSpec({
 
     const rowFacetField = rowLeftFacetFields.length > 0 ? rowLeftFacetFields[rowLeftFacetFields.length - 1] : NULL_FIELD;
     const colFacetField = colLeftFacetFields.length > 0 ? colLeftFacetFields[colLeftFacetFields.length - 1] : NULL_FIELD;
-    const geomFieldIds = [...rows, ...columns, color, opacity, size, ...details]
+    const geomFieldIds = [...rows, ...columns, color, opacity, size, z, ...details]
         .filter((f) => Boolean(f))
         .filter((f) => f!.aggName !== 'expr')
         .map((f) => (f as IViewField).fid);
@@ -112,6 +114,7 @@ export function toVegaSpec({
         const v = getSingleView({
             x: xField,
             y: yField,
+            z: guard(z),
             color: guard(color),
             opacity: guard(opacity),
             size: guard(size),
@@ -175,6 +178,7 @@ export function toVegaSpec({
                 const v = getSingleView({
                     x: colRepeatFields[j] || NULL_FIELD,
                     y: rowRepeatFields[i] || NULL_FIELD,
+                    z: guard(z),
                     color: guard(color),
                     opacity: guard(opacity),
                     size: guard(size),

--- a/packages/graphic-walker/src/vis/spec/encode.ts
+++ b/packages/graphic-walker/src/vis/spec/encode.ts
@@ -6,6 +6,7 @@ export interface IEncodeProps {
     geomType: string;
     x: IViewField;
     y: IViewField;
+    z: IViewField;
     color: IViewField;
     opacity: IViewField;
     size: IViewField;
@@ -23,12 +24,12 @@ export interface IEncodeProps {
 }
 export function availableChannels(geomType: string): Set<string> {
     if (geomType === 'text') {
-        return new Set(['text', 'color', 'size', 'x', 'y', 'xOffset', 'yOffset', 'opacity']);
+        return new Set(['text', 'color', 'size', 'x', 'y', 'z', 'xOffset', 'yOffset', 'opacity']);
     }
     if (geomType === 'arc') {
         return new Set(['opacity', 'color', 'size', 'theta', 'radius']);
     }
-    return new Set(['column', 'opacity', 'color', 'row', 'size', 'x', 'y', 'xOffset', 'yOffset', 'shape']);
+    return new Set(['column', 'opacity', 'color', 'row', 'size', 'x', 'y', 'z', 'xOffset', 'yOffset', 'shape']);
 }
 function encodeTimeunit(unit: (typeof DATE_TIME_DRILL_LEVELS)[number]) {
     switch (unit) {

--- a/packages/graphic-walker/src/vis/spec/view.ts
+++ b/packages/graphic-walker/src/vis/spec/view.ts
@@ -26,6 +26,7 @@ export function getSingleView(props: SingleViewProps) {
     const {
         x,
         y,
+        z,
         color,
         opacity,
         size,
@@ -47,7 +48,7 @@ export function getSingleView(props: SingleViewProps) {
         dataSource,
         vegaConfig,
     } = props;
-    const fields: IViewField[] = [x, y, color, opacity, size, shape, row, column, xOffset, yOffset, theta, radius, text];
+    const fields: IViewField[] = [x, y, z, color, opacity, size, shape, row, column, xOffset, yOffset, theta, radius, text];
     let markType = geomType;
     let config: any = {};
     if (!hasLegend) {
@@ -108,6 +109,7 @@ export function getSingleView(props: SingleViewProps) {
         geomType: markType,
         x,
         y,
+        z,
         color,
         opacity,
         size,


### PR DESCRIPTION
## Summary
- add `z` to `IEncodeProps` and `availableChannels`
- include `z` in single view fields
- guard `z` in `toVegaSpec` and pass it to `getSingleView`

## Testing
- `yarn test` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_685a70ee5c20832a882d9f2e960c4ef8